### PR TITLE
Fix unexpected O(N) behavior when replaying a single file

### DIFF
--- a/src/replay.c
+++ b/src/replay.c
@@ -239,7 +239,7 @@ main (int argc, char **argv, char **environ)
 	    {
 	      snprintf (s->time.str, BUFSIZ - 1, "%s/%s",
 			config_option.logdir, dirp->d_name);
-	      count_dur (s);
+	      if (!argc) count_dur (s);
 	    }
 
 	  s->e = e;
@@ -263,7 +263,7 @@ main (int argc, char **argv, char **environ)
 	    {
 	      snprintf (s->time.str, BUFSIZ - 1, "%s/%s",
 			config_option.logdir, dirp->d_name);
-	      count_dur (s);
+	      if (!argc) count_dur (s);
 	    }
 	}
     }


### PR DESCRIPTION
Previously when attempting to replay a single recording that was within a directory containing a large number of other recordings, sudosh opened and scanned through _every_ file within the directory before loading the replay. This is due to shared code that called the count_dur function within the main loop. This was fixed by scoping count_dur to conditions where we need it (e.g. listing all replays).

This is a hacky fix that should really encourage the entire replay entry function to be re-written as two separate code paths to prevent cases with O(N)'s or other broken files.

Both this and my other PR come from our heavy use of sudosh. We have around 45,000 recordings at this point which are unusable unless we move them to a separate directory. I'd love to contribute some more extensive patches to the overall code-flow and path of the replay program to actually fix these problems vs hacking around them. If you think thats something which would be helpful, and you'd be comfortable reviewing/merging give me a heads up and I can take a stab at some more complete fixes.