### PR TITLE
Append.only.immutable

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -46,6 +46,7 @@ the executable file might be covered by the GNU General Public License. */
 #endif
 
 #include <stdio.h>
+#include <string.h>
 
 /* Comment out all this code if we are using the GNU C Library, and are not
    actually compiling the library itself.  This code is part of the GNU C

--- a/src/parse.c
+++ b/src/parse.c
@@ -26,12 +26,15 @@ parse (option * c, const char *file)
   c->priority = -1;		// No defaults here
   c->facility = -1;		// or here...
   c->clearenvironment = 1;
+  c->immutable_recordings = 0;
   f = fopen (file, "r");
   if (f == NULL)
     {
-      fprintf (stderr,
-	       "Warning: No config file found. Using compiled-in defaults:\nLogdir\t%s\nDefault Shell:\t%s\nSyslog disabled\n",
-	       c->logdir, c->defshell);
+      fprintf (stderr, "Warning: No config file found. Using compiled-in defaults:\n");
+      fprintf (stderr, "Logdir\t%s\n", c->logdir);
+      fprintf (stderr, "Default Shell:\t%s\n", c->defshell);
+      fprintf (stderr, "Syslog Disabled\t%s\n");
+      fprintf (stderr, "Immutable Recordings Disabled\t%s\n");
       // Just run with the defaults, ignore the rest
       return;
     }
@@ -88,6 +91,23 @@ parse (option * c, const char *file)
 
       if (strcmp (key, "delimiter") == 0)
 	c->fdl = value[0];
+
+      if (strcmp (key, "immutable_recordings") == 0)
+        {
+          if (strcmp (value, "enabled") == 0)
+            {
+              c->immutable_recordings = 1;
+            }
+          else if (strcmp (value, "disabled") == 0)
+            {
+              c->immutable_recordings = 0;
+            }
+          else
+            {
+              fprintf (stderr, "Wrong config option: 'immutable_recording = %s'\n", value);
+              exit (EXIT_FAILURE);
+            }
+        }
 
       if (strcmp (key, "syslog.facility") == 0)
 	{			// I really hate the way this is done...

--- a/src/struct.h
+++ b/src/struct.h
@@ -6,6 +6,7 @@ struct s_option {
     int priority;
     int facility;
     int clearenvironment;
+    int immutable_recordings;
     char argallow[BUFSIZ];
 };
 

--- a/src/sudosh.c
+++ b/src/sudosh.c
@@ -26,7 +26,7 @@ PURPOSE.  See the Open Software License for details.
 #define SIGCHLD	SIGCLD
 #endif
 
-#define WRITE(a, b, c) do_write(a, b, c, __FILE__, __LINE__)
+#define DO_WRITE(a, b, c) do_write(a, b, c, __FILE__, __LINE__)
 
 static struct termios termorig;
 static struct winsize winorig;
@@ -476,12 +476,12 @@ main (int argc, char *argv[], char *environ[])
 	{
 	  if ((n = read (pspair.mfd, iobuf, sizeof (iobuf))) > 0)
 	    {
-	      WRITE (1, iobuf, n);
-	      script.bytes += WRITE (script.fd, iobuf, n);
+	      DO_WRITE (1, iobuf, n);
+	      script.bytes += DO_WRITE (script.fd, iobuf, n);
 	    }
 	  newtime = tv.tv_sec + (double) tv.tv_usec / 1000000;
 	  snprintf (timing.str, BUFSIZ - 1, "%f %i\n", newtime - oldtime, n);
-	  timing.bytes += WRITE (timing.fd, &timing.str, strlen (timing.str));
+	  timing.bytes += DO_WRITE (timing.fd, &timing.str, strlen (timing.str));
 	  oldtime = newtime;
 
 	}
@@ -490,7 +490,7 @@ main (int argc, char *argv[], char *environ[])
 	{
 	  if ((n = read (0, iobuf, BUFSIZ)) > 0)
 	    {
-	      WRITE (pspair.mfd, iobuf, n);
+	      DO_WRITE (pspair.mfd, iobuf, n);
 #ifdef RECORDINPUT
 	      switch (*iobuf)
 		{
@@ -510,14 +510,14 @@ main (int argc, char *argv[], char *environ[])
 		  snprintf (input.str, BUFSIZ - 1, "(ESC)");
 		  break;
 		default:
-		  WRITE (input.fd, iobuf, 1);
+		  DO_WRITE (input.fd, iobuf, 1);
 		  written = 1;
 		  break;
 		}
 
 	      if (written == 0)
 		{
-		  WRITE (input.fd, &input.str, strlen (input.str));
+		  DO_WRITE (input.fd, &input.str, strlen (input.str));
 		}
 #endif
 	    }

--- a/src/sudosh.c
+++ b/src/sudosh.c
@@ -728,6 +728,7 @@ do_write (int fd, void *buf, size_t size, char *file, unsigned int line)
   return s;
 }
 
+#ifdef __linux__
 void set_file_flag(struct s_file *file, int flag) {
   int flags = 0;
   if (ioctl(file->fd, FS_IOC_GETFLAGS, &flags) == -1 ) {
@@ -753,6 +754,7 @@ void unset_file_flag(struct s_file *file, int flag) {
     exit (EXIT_FAILURE);
   }
 }
+#endif
 
 void set_perms_and_close_file(struct s_file *file) {
 #ifdef __linux__

--- a/src/sudosh.c
+++ b/src/sudosh.c
@@ -758,13 +758,15 @@ void unset_file_flag(struct s_file *file, int flag) {
 
 void set_perms_and_close_file(struct s_file *file) {
 #ifdef __linux__
-  unset_file_flag(file, FS_APPEND_FL);
+  if (sudosh_option.immutable_recordings)
+    unset_file_flag(file, FS_APPEND_FL);
 #endif
   if (fchmod (file->fd, S_IRUSR | S_IRGRP) == -1 ) {
     printf("Unable to chmod file %s: %s\n", file->name, strerror(errno));
   }
 #ifdef __linux__
-  set_file_flag(file, FS_IMMUTABLE_FL);
+  if (sudosh_option.immutable_recordings)
+    set_file_flag(file, FS_IMMUTABLE_FL);
 #endif
   if (close (file->fd) == -1 ) {
     printf("Unable to close file %s: %s\n", file->name, strerror(errno));
@@ -787,6 +789,7 @@ void set_perms_and_open_file(struct s_file *file) {
       exit (EXIT_FAILURE);
     }
 #ifdef __linux__
+  if (sudosh_option.immutable_recordings)
     set_file_flag(file, FS_APPEND_FL);
 #endif
 }

--- a/sudosh.conf.5.in
+++ b/sudosh.conf.5.in
@@ -18,6 +18,13 @@ Use this to set the default logging directory.  Both sudosh and sudosh-replay wi
 .RS
 default shell = /path/to/default/shell
 This is the default shell sudosh will use if it cannot automatically determine which shell to use..RE
+.RE
+.IP "immutable_recordings"
+.RS
+immutable_recordings = (enabled|disabled)
+If enabled sets the append only flag on new recordings and changes the recording to
+immutable once it is complete. Only available on Linux, default disabled.
+.RE
 .IP delimiter
 .RS
 delimiter = -
@@ -44,6 +51,8 @@ This option can be used multiple times.  If you wish to use sudosh as a default 
 # Sudosh Configuration File
 .RE
 logdir                  = /var/log/sudosh
+.RE
+immutable_recordings    = enabled
 .RE
 default shell           = /bin/sh
 .RE

--- a/sudosh.conf.5.in
+++ b/sudosh.conf.5.in
@@ -1,5 +1,5 @@
 .\" Process this file with
-.\" groff -man -Tascii sudosh.1
+.\" groff -man -Tascii sudosh.conf.5
 .\"
 
 .TH SUDOSH.CONF 5 "December 21th 2007" @VERSION@ "User Manuals"


### PR DESCRIPTION
This pull request sets the append only flag on the files so that a user cannot truncate the files before exiting their shell.

This commit is based off of this commit by @joeripronk https://github.com/joeripronk/sudosh3/commit/d7b25e030b7f80bfcd3734d6bceb07edbd5a66ee

After the files are done being written to, we set the immutable flag so that they cannot be altered, we also chmod them to be readable by the users primary group.

I have ifdefed the necessary code so that it at least compiles on DragonflyBSD

I would love any stylistic or cross os suggestions, I have written very little C code.