### PR TITLE
Fix Alpine musl and Gentoo CI build failures

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,7 @@ jobs:
               INSTALL="zypper -n refresh && zypper -n install gcc make autoconf automake"
               ;;
             emerge)
-              INSTALL="emerge --sync 2>/dev/null; emerge -q sys-devel/gcc sys-devel/autoconf sys-devel/automake"
+              INSTALL="emerge --sync 2>/dev/null; emerge -q1 sys-apps/portage 2>/dev/null; emerge -q sys-devel/gcc sys-devel/autoconf sys-devel/automake"
               ;;
           esac
 

--- a/build-test/check-errors.sh
+++ b/build-test/check-errors.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd /tmp/sudosh2
+docker run --rm -v "$PWD:/src:ro" ubuntu:24.04 bash <<'DOCKER'
+apt-get update -qq > /dev/null 2>&1
+apt-get install -y -qq gcc make autoconf automake libtool > /dev/null 2>&1
+cp -r /src /tmp/b
+cd /tmp/b
+autoreconf -fi 2>&1 | tail -1
+./configure --prefix=/usr --sysconfdir=/etc > /dev/null 2>&1
+make CFLAGS='-Wall -Werror -pedantic' 2>&1 | grep -E 'error:|warning:|Error' | head -20
+echo "---EXIT:$?---"
+DOCKER

--- a/build-test/check-strict.sh
+++ b/build-test/check-strict.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd /tmp/sudosh2
+echo "=== Strict gcc-15 simulation ==="
+docker run --rm -v "$PWD:/src:ro" ubuntu:24.04 bash -c '
+apt-get update -qq > /dev/null 2>&1
+apt-get install -y -qq gcc make autoconf automake libtool > /dev/null 2>&1
+cp -r /src /tmp/b
+cd /tmp/b
+autoreconf -fi 2>&1 | tail -1
+./configure --prefix=/usr --sysconfdir=/etc > /dev/null 2>&1
+echo "--- MAKE OUTPUT ---"
+make CFLAGS="-Werror=implicit-function-declaration -Werror=int-conversion -std=c17 -O2" 2>&1
+echo "--- EXIT: $? ---"
+'

--- a/build-test/run-quick.sh
+++ b/build-test/run-quick.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+cd /tmp/sudosh2
+
+test_distro() {
+    local image="$1"
+    local pkg_cmd="$2"
+    local name="$3"
+    echo "=== Testing: $name ==="
+    docker run --rm -v "$PWD:/src:ro" "$image" bash -c "
+        set -e
+        $pkg_cmd > /dev/null 2>&1
+        cp -r /src /tmp/b && cd /tmp/b
+        autoreconf -fi 2>&1 | tail -1
+        ./configure --prefix=/usr --sysconfdir=/etc > /dev/null 2>&1
+        make CFLAGS='-Wall -Werror -pedantic' 2>&1 | tail -3
+        echo BUILD_SUCCESS
+    " 2>&1 | tail -5
+    echo ""
+}
+
+# Test strict mode (Gentoo sim)
+echo "=== Testing: Gentoo sim (strict flags) ==="
+docker run --rm -v "$PWD:/src:ro" ubuntu:24.04 bash -c "
+    set -e
+    apt-get update -qq > /dev/null 2>&1
+    apt-get install -y -qq gcc make autoconf automake libtool > /dev/null 2>&1
+    cp -r /src /tmp/b && cd /tmp/b
+    autoreconf -fi 2>&1 | tail -1
+    ./configure --prefix=/usr --sysconfdir=/etc > /dev/null 2>&1
+    make CFLAGS='-Wall -Werror -pedantic -Werror=implicit-function-declaration -Werror=int-conversion -std=c17 -O2' 2>&1 | tail -5
+    echo BUILD_SUCCESS
+" 2>&1 | tail -8
+echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,7 @@ AC_CHECK_HEADERS(sgtty.h pty.h signal.h time.h sys/time.h fcntl.h stropts.h)
 AC_CHECK_HEADERS(util.h termios.h sys/termios.h sys/types.h libutil.h)
 AC_CHECK_HEADERS(features.h sys/ioctl.h pwd.h syslog.h usersec.h)
 AC_CHECK_HEADERS(limits.h sys/stat.h sys/param.h dirent.h ctype.h strings.h)
+AC_CHECK_HEADERS([linux/fs.h], [], [], [#include <sys/ioctl.h>])
 
 AC_CHECK_FUNCS(openpty, openpty=1, openpty=0)
 AC_CHECK_FUNCS([getusershell gettimeofday])

--- a/src/sudosh.c
+++ b/src/sudosh.c
@@ -22,7 +22,21 @@ PURPOSE.  See the Open Software License for details.
 #include "struct.h"
 #include "super.h"
 #ifdef __linux__
+#include <sys/ioctl.h>
+#ifdef HAVE_LINUX_FS_H
 #include <linux/fs.h>
+#else
+/* Fallback definitions for systems without <linux/fs.h> (e.g., musl libc) */
+#ifndef FS_IOC_GETFLAGS
+#define FS_IOC_GETFLAGS _IOR('f', 1, long)
+#endif
+#ifndef FS_IOC_SETFLAGS
+#define FS_IOC_SETFLAGS _IOW('f', 2, long)
+#endif
+#ifndef FS_APPEND_FL
+#define FS_APPEND_FL 0x00000020
+#endif
+#endif
 #endif
 
 #ifndef SIGCHLD


### PR DESCRIPTION
Fixes two CI failures:

1. Alpine 3.21: linux/fs.h not available under musl libc. Added configure detection and fallback definitions for FS_IOC_GETFLAGS, FS_IOC_SETFLAGS, FS_APPEND_FL.

2. Gentoo: portage needs updating before emerge works on current stage3. Added emerge -q1 sys-apps/portage step.

Also added AC_CHECK_HEADERS for linux/fs.h in configure.ac.